### PR TITLE
Install APCu stable version

### DIFF
--- a/roles/php/tasks/apc.yml
+++ b/roles/php/tasks/apc.yml
@@ -1,7 +1,7 @@
 --- 
 - name: Install APCu
   sudo: True
-  command: pecl install apcu-beta
+  command: pecl install apcu
 
 - name: Add APCu
   sudo: True


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.